### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "debug": "1.0.4",
+    "debug": "2.2.0",
     "koa-mount": "1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
resourcer is currently affected by the low-severity vulnerability [ReDOS vulnerability](https://snyk.io/vuln/npm:ms:20151024). 

Vulnerable module: `ms`
Introduced through: `debug`

This PR fixes the ReDOS vulnerability by upgrading `debug` to version 2.2.0.

This fix is a major version upgrade, and therefore a potentially breaking change. Please review the PR carefully. 

You are already watching this repo with Snyk, so check out [the project](https://snyk.io/test/github/koajs/resourcer) to review other vulnerabilities that affect this repo, and generate a PR to fix more vulnerabilities. 

Stay secure, 
The Snyk team
